### PR TITLE
Allow protection plugins to cancel this event.

### DIFF
--- a/src/Heisenburger69/SellWands/Main.php
+++ b/src/Heisenburger69/SellWands/Main.php
@@ -59,9 +59,18 @@ class Main extends PluginBase implements Listener {
                 return false;
         }
     }
+    /**
+    *
+    * @param PlayerInteractEvent $event
+    * @priority MONITOR
+    *
+    */
 
     public function onInteract(PlayerInteractEvent $event)
     {
+        if($event->isCancelled()){
+        return;
+        }
         if ($event->getAction() === PlayerInteractEvent::RIGHT_CLICK_BLOCK) {
             $player = $event->getPlayer();
             if(!$player->hasPermission("sellwand.use")) {


### PR DESCRIPTION

This pull request makes it so protection plugins can cancel this event before this plugin’s event gets called, disallowing other players to no longer sell on other player’s islands (Skyblock), and other world protection plugins.
This PR should fix #1, and #2.
Please merge whenever possible. Thank you.